### PR TITLE
bgv: Support loading array of integers and doubles

### DIFF
--- a/lib/seafoam/bgv_parser.rb
+++ b/lib/seafoam/bgv_parser.rb
@@ -309,6 +309,14 @@ module Seafoam
           @reader.read_sint32.times.map do
             read_pool_object
           end
+        when PROPERTY_INT
+          @reader.read_sint32.times.map do
+            @reader.read_sint32
+          end
+        when PROPERTY_DOUBLE
+          @reader.read_sint32.times.map do
+            @reader.read_float64
+          end
         else
           raise EncodingError, "unknown BGV property array type 0x#{type.to_s(16)}"
         end


### PR DESCRIPTION
I ran into this while playing around with graphs of different Java
programs. `switch` needs support for these.

https://github.com/oracle/graal/blob/fff7b99a8a502b8382cddda06c90f339bf5f2525/compiler/src/org.graalvm.graphio/src/org/graalvm/graphio/GraphProtocol.java#L802