### PR TITLE
Fix filename parsing behaviour

### DIFF
--- a/lib/seafoam/commands.rb
+++ b/lib/seafoam/commands.rb
@@ -418,8 +418,12 @@ module Seafoam
 
     # Parse a name like file.bgv:g:n-e to [file.bgv, g, n, e].
     def parse_name(name)
-      *pre, file, graph, node = name.split(':')
-      file = [*pre, file].join(':')
+      *pre, post = name.split('.')
+
+      file_ext, graph, node, *rest = post.split(':')
+      raise ArgumentError, "too many parts to .ext:g:n-e in #{name}" unless rest.empty?
+
+      file = [*pre, file_ext].join('.')
 
       if node
         node, edge, *rest = node.split('-')

--- a/spec/seafoam/command_spec.rb
+++ b/spec/seafoam/command_spec.rb
@@ -256,5 +256,13 @@ describe Seafoam::Commands do
       expect(node).to be_nil
       expect(edge).to be_nil
     end
+
+    it 'parses a BGV.gz file name with periods and colons' do
+      file, graph, node, edge = @commands.send(:parse_name, 'TruffleHotSpotCompilation-13029[Truffle::ThreadOperations.detect_recursion_<split-3a5973bc>].bgv.gz:4')
+      expect(file).to eq 'TruffleHotSpotCompilation-13029[Truffle::ThreadOperations.detect_recursion_<split-3a5973bc>].bgv.gz'
+      expect(graph).to eq 4
+      expect(node).to be_nil
+      expect(edge).to be_nil
+    end
   end
 end

--- a/spec/seafoam/command_spec.rb
+++ b/spec/seafoam/command_spec.rb
@@ -248,5 +248,13 @@ describe Seafoam::Commands do
       expect(node).to eq 12
       expect(edge).to eq 81
     end
+
+    it 'parses a BGV file name with periods and colons' do
+      file, graph, node, edge = @commands.send(:parse_name, 'TruffleHotSpotCompilation-13029[Truffle::ThreadOperations.detect_recursion_<split-3a5973bc>].bgv:4')
+      expect(file).to eq 'TruffleHotSpotCompilation-13029[Truffle::ThreadOperations.detect_recursion_<split-3a5973bc>].bgv'
+      expect(graph).to eq 4
+      expect(node).to be_nil
+      expect(edge).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Previously there were unexpected results when there was a ":" in the filename.