### PR TITLE
Support for drawing basic blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Admittedly, Seafoam does not yet have:
 
 * an interactive user interface
 * diffing of graphs
-* visualization of basic blocks
 * breaking of edges for very congested graphs
 * the same speed in rendering big graphs - Seafoam is best suited for looking at graphs before lowering, which is what language developers are usually doing, or use spotlight
 
@@ -101,6 +100,8 @@ This is just a quick summary - see more information on
 ```
 % native-image -H:Dump=:2 -H:MethodFilter=fib Fib
 ```
+
+Note that if you want basic block information to appear, the `-H:+PrintGraphWithSchedule` flag is also needed.
 
 ### TruffleRuby and other Truffle languages
 
@@ -305,6 +306,7 @@ graph0 = # 2:Fib.fib(int)/After phase org.graalvm.compiler.java.GraphBuilderPhas
 * `--show-frame-state` shows frame state nodes, which are hidden by default
 * `--hide-floating` hides nodes that aren't fixed by control flow
 * `--no-reduce-edges` turns off the option to reduce the number of edges by inlining simple nodes above their users
+* `--draw-blocks` to draw basic block information if available
 
 ## Configuration
 

--- a/docs/bgv.md
+++ b/docs/bgv.md
@@ -57,7 +57,8 @@ GraphBody {
   Props props
   sint32 nodes_count
   Node[nodes_count] nodes
-  Blocks blocks
+  sint32 blocks_count
+  Blocks[blocks_count] blocks
 }
 
 Node {

--- a/lib/seafoam/bgv/bgv_parser.rb
+++ b/lib/seafoam/bgv/bgv_parser.rb
@@ -127,7 +127,14 @@ module Seafoam
             end
           end
         end
-        skip_blocks
+        # read block information
+        @reader.read_sint32.times do
+          block_id = @reader.read_sint32
+          block_nodes = @reader.read_sint32.times.map { @reader.read_sint32 }
+          # not used
+          followers = @reader.read_sint32.times.map { @reader.read_sint32 }
+          graph.create_block(block_id, block_nodes)
+        end
         graph
       end
 

--- a/lib/seafoam/commands.rb
+++ b/lib/seafoam/commands.rb
@@ -30,6 +30,7 @@ module Seafoam
         @out.puts '               --show-frame-state'
         @out.puts '               --hide-floating'
         @out.puts '               --no-reduce-edges'
+        @out.puts '               --draw-blocks'
         @out.puts '               --option key value'
         @out.puts '        --help'
         @out.puts '        --version'
@@ -406,6 +407,7 @@ module Seafoam
       args = args.dup
       out_file = nil
       explicit_out_file = false
+      draw_blocks = false
       until args.empty?
         arg = args.shift
         case arg
@@ -424,6 +426,8 @@ module Seafoam
           annotator_options[:hide_floating] = true
         when '--no-reduce-edges'
           annotator_options[:reduce_edges] = false
+        when '--draw-blocks'
+          draw_blocks = true
         when '--option'
           key = args.shift
           raise ArgumentError, 'no key for --option' unless key
@@ -469,14 +473,14 @@ module Seafoam
         if out_format == :dot
           File.open(out_file, 'w') do |stream|
             writer = GraphvizWriter.new(stream)
-            writer.write_graph graph
+            writer.write_graph graph, false, draw_blocks
           end
         else
           begin
             IO.popen(['dot', "-T#{out_format}", '-o', out_file], 'w') do |stream|
               writer = GraphvizWriter.new(stream)
               hidpi = out_format == :png
-              writer.write_graph graph, hidpi
+              writer.write_graph graph, hidpi, draw_blocks
             end
           rescue Errno::ENOENT
             raise 'Could not run Graphviz - is it installed?'

--- a/lib/seafoam/graph.rb
+++ b/lib/seafoam/graph.rb
@@ -2,12 +2,13 @@ module Seafoam
   # A graph, with properties, nodes, and edges. We don't encapsulate the graph
   # too much - be careful.
   class Graph
-    attr_reader :props, :nodes, :edges
+    attr_reader :props, :nodes, :edges, :blocks
 
     def initialize(props = nil)
       @props = props || {}
       @nodes = {}
       @edges = []
+      @blocks = []
     end
 
     # Create a node.
@@ -26,6 +27,14 @@ module Seafoam
       from.outputs.push edge
       to.inputs.push edge
       edge
+    end
+
+    # Add a new basic block with given id and node id list
+    def create_block(id, node_ids)
+      nodes = node_ids.select { |id| @nodes.key? id }.map { |id| @nodes[id] }
+      block = Block.new(id, nodes)
+      @blocks.push block
+      block
     end
   end
 
@@ -86,6 +95,21 @@ module Seafoam
     # Inspect.
     def inspect
       "<Edge #{from.id} -> #{to.id}>"
+    end
+  end
+
+  # A control-flow basic block
+  class Block
+    attr_reader :id, :nodes
+
+    def initialize(id, nodes)
+      @id = id
+      @nodes = nodes
+    end
+
+    # Inspect.
+    def inspect
+      "<Block #{id}>"
     end
   end
 end

--- a/lib/seafoam/graphviz_writer.rb
+++ b/lib/seafoam/graphviz_writer.rb
@@ -7,7 +7,7 @@ module Seafoam
     end
 
     # Write a graph.
-    def write_graph(graph, hidpi = false)
+    def write_graph(graph, hidpi = false, draw_blocks = false)
       inline_attrs = {}
       attrs = {}
       attrs[:dpi] = 200 if hidpi
@@ -16,6 +16,7 @@ module Seafoam
       @stream.puts "  graph #{write_attrs(attrs)};"
       write_nodes inline_attrs, graph
       write_edges inline_attrs, graph
+      write_blocks graph if draw_blocks
       @stream.puts '}'
     end
 
@@ -163,6 +164,23 @@ module Seafoam
       else
         # Declare the edge.
         @stream.puts "  node#{edge.from.id} -> node#{edge.to.id} #{write_attrs(attrs)};"
+      end
+    end
+
+    # Write basic block outlines.
+    def write_blocks(graph)
+      graph.blocks.each do |block|
+        @stream.puts "  subgraph cluster_block#{block.id} {"
+        @stream.puts "    fontname = \"Arial\";"
+        @stream.puts "    label = \"B#{block.id}\";"
+        @stream.puts '    style=dotted;'
+
+        block.nodes.each do |node|
+          next if (node.props[:hidden] || node.props[:inlined])
+          @stream.puts "    node#{node.id};"
+        end
+
+        @stream.puts '  }'
       end
     end
 


### PR DESCRIPTION
This change allows the visualisation (via a CLI flag) of basic blocks - if the information is available in the BGV file - as seen below:

![graph](https://user-images.githubusercontent.com/3010837/120249906-b5d35480-c2bf-11eb-82be-868e2b4af762.png)

Still a WIP, but this has been useful for us and I wanted to see your thoughts? @chrisseaton 