### PR TITLE
Hide pi nodes by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ graph0 = # 2:Fib.fib(int)/After phase org.graalvm.compiler.java.GraphBuilderPhas
 ## Options for GraalVM graphs
 
 * `--show-frame-state` shows frame state nodes, which are hidden by default
+* `--show-pi` shows 'pi' nodes, which are hidden by default
 * `--hide-floating` hides nodes that aren't fixed by control flow
 * `--no-reduce-edges` turns off the option to reduce the number of edges by inlining simple nodes above their users
 * `--draw-blocks` to draw basic block information if available

--- a/docs/passes.md
+++ b/docs/passes.md
@@ -21,12 +21,13 @@ want to add them:
 
 * `:label` on nodes and edges
 * `:out_annotation` on nodes
-* `:hidden` on nodes only, to not show them (*remove frame state* for example in IGV terminology)
+* `:hidden` on nodes and edges, to not show them (*remove frame state* for example in IGV terminology)
 * `:inlined` on nodes only, to indicate the node should be shown immediately above each node using it (*reduce edges* in IGV terminology)
 * `:kind` on nodes only, which can be `info`, `input`, `control`, `effect`, `virtual`, `calc`, `guard`, or `other`
 * `:kind` on edges only, which can be `info`, `control`, `loop`, or `data`
 * `:reverse` on edges only
 * `:spotlight` for nodes as part of spotlighting (`lit` are shown, `shaded` are shown but greyed out, and edges from `shaded` to `:hidden` nodes are also shown greyed out)
+* `:synthetic` on nodes edges which were added by passes and not in the original graph
 
 Seafoam ships with a pass for generic GraalVM graphs. If you work with a
 different compiler you'll probably want to write your own pass.

--- a/lib/seafoam/commands.rb
+++ b/lib/seafoam/commands.rb
@@ -381,6 +381,7 @@ module Seafoam
 
       pass_options = {
         hide_frame_state: true,
+        hide_pi: true,
         hide_floating: false,
         reduce_edges: true
       }
@@ -403,6 +404,8 @@ module Seafoam
           spotlight_nodes = spotlight_arg.split(',').map { |n| Integer(n) }
         when '--show-frame-state'
           pass_options[:hide_frame_state] = false
+        when '--show-pi'
+          pass_options[:hide_pi] = false
         when '--hide-floating'
           pass_options[:hide_floating] = true
         when '--no-reduce-edges'
@@ -565,6 +568,7 @@ module Seafoam
       @out.puts '                    graph.png'
       @out.puts '                    graph.dot'
       @out.puts '               --show-frame-state'
+      @out.puts '               --show-pi'
       @out.puts '               --hide-floating'
       @out.puts '               --no-reduce-edges'
       @out.puts '               --draw-blocks'

--- a/lib/seafoam/graphviz_writer.rb
+++ b/lib/seafoam/graphviz_writer.rb
@@ -100,6 +100,9 @@ module Seafoam
         # from a shaded node.
         next if edge.to.props[:hidden] && edge.from.props[:spotlight] != 'shaded'
 
+        # Skip the edge if it's hidden itself
+        next if edge.props[:hidden]
+
         write_edge inline_attrs, edge
       end
     end

--- a/lib/seafoam/passes/graal.rb
+++ b/lib/seafoam/passes/graal.rb
@@ -93,6 +93,11 @@ module Seafoam
             name_template = 'π'
           end
 
+          # Use a symbol for PiArrayNode.
+          if node_class == 'org.graalvm.compiler.nodes.PiArrayNode'
+            name_template = '[π]'
+          end
+
           # Use a symbol for PhiNode.
           if node_class == 'org.graalvm.compiler.nodes.ValuePhiNode'
             name_template = 'ϕ'

--- a/spec/seafoam/passes/graal_spec.rb
+++ b/spec/seafoam/passes/graal_spec.rb
@@ -63,6 +63,21 @@ describe Seafoam::Passes::GraalPass do
       end
     end
 
+    describe 'with :hide_pi' do
+      before :all do
+        @graph = Seafoam::SpecHelpers.example_graph('fib-ruby', 2)
+        pass = Seafoam::Passes::GraalPass.new(hide_pi: true)
+        pass.apply @graph
+      end
+
+      it 'sets the hidden property on all frame state nodes' do
+        frame_state_nodes = @graph.nodes.values.select do |n|
+          Seafoam::Passes::GraalPass::PI_NODES.include?(n.props.dig(:node_class, :node_class))
+        end
+        expect(frame_state_nodes.all? { |n| n.props[:hidden] }).to be_truthy
+      end
+    end
+
     describe 'with :hide_floating' do
       before :all do
         @graph = Seafoam::SpecHelpers.example_graph('fib-ruby', 2)


### PR DESCRIPTION
Pi nodes are nodes that add type information. They're useful for optimisation, but not for day-to-day understanding of graphs. They also tend to add choke-points for the layout of graphs.

For example look at the `==` node here.

Before:

![before](https://user-images.githubusercontent.com/341094/128641560-20aa8248-195e-4631-aa7d-226b055df03f.png)

After:

![after](https://user-images.githubusercontent.com/341094/128641565-5b4d89e3-0810-4a81-8514-6837ed3907aa.png)