### PR TITLE
Add option to not simplify, and run passes before describe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
-Gemfile.lock
-*.pdf
-*.dot
-*.png
-*.svg
-*.class
+/Gemfile.lock
 /.idea

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,5 +2,7 @@ inherit_gem:
   rubocop-shopify: rubocop.yml
 
 AllCops:
+  SuggestExtensions: false
+  NewCops: disable
   Exclude:
     - examples/**/*.rb

--- a/README.md
+++ b/README.md
@@ -458,11 +458,13 @@ graph0 = # 2:Fib.fib(int)/After phase org.graalvm.compiler.java.GraphBuilderPhas
 ## Options for GraalVM graphs
 
 * `--full-truffle-args` shows full Truffle argument nodes, which are simplified by default
-* `--no-simplify-alloc` turns off the option to hide null and zero fields in object allocations in Truffle
 * `--show-frame-state` shows frame state nodes, which are hidden by default
-* `--show-pi` shows 'pi' nodes, which are hidden by default
+* `--no-simplify-alloc` turns off the pass to create synthetic allocation nodes
+* `--show-null-fields` shows null fields to allocations, which are hidden by default
+* `--show-pi` shows *pi* nodes, which are hidden by default
+* `--show-begin-end` shows *begin* and *end* nodes, which are hidden by default
 * `--hide-floating` hides nodes that aren't fixed by control flow
-* `--no-reduce-edges` turns off the option to reduce the number of edges by inlining simple nodes above their users
+* `--no-reduce-edges` turns off the pass to reduce the number of edges by inlining simple nodes above their users
 * `--draw-blocks` to draw basic block information if available
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ graph0 = # 2:Fib.fib(int)/After phase org.graalvm.compiler.java.GraphBuilderPhas
 * `--show-begin-end` shows *begin* and *end* nodes, which are hidden by default
 * `--hide-floating` hides nodes that aren't fixed by control flow
 * `--no-reduce-edges` turns off the pass to reduce the number of edges by inlining simple nodes above their users
+* `--no-simplify` turns off passes that simplify the graph, except frame states are still hidden
 * `--draw-blocks` to draw basic block information if available
 
 ## Debugging

--- a/lib/seafoam/commands.rb
+++ b/lib/seafoam/commands.rb
@@ -350,10 +350,20 @@ module Seafoam
     def describe(name, formatter_module, *args)
       file, graph_index, *rest = parse_name(name)
 
+      pass_options = DEFAULT_PASS_OPTIONS.dup
+      until args.empty?
+        arg = args.shift
+        case arg
+        when "--no-simplify"
+          pass_options.merge!(NO_SIMPLIFY_PASS_OPTIONS)
+        else
+          raise ArgumentError, "unexpected option #{arg}"
+        end
+      end
+
       if graph_index.nil? || !rest.all?(&:nil?)
         raise ArgumentError, "describe only works with a graph"
       end
-      raise ArgumentError, "describe does not take arguments" unless args.empty?
 
       parser = BGV::BGVParser.new(file)
       parser.read_file_header
@@ -371,26 +381,33 @@ module Seafoam
         end
 
         graph = parser.read_graph
+        Passes.apply(graph, pass_options)
+
         description = Seafoam::Graal::GraphDescription.new
 
         graph.nodes.each_value do |node|
+          next if node.props[:hidden]
+
           node_class = node.node_class
+          if node_class
+            simple_node_class = node_class[/([^.]+)$/, 1]
+            description.node_counts[simple_node_class] += 1
 
-          simple_node_class = node_class[/([^.]+)$/, 1]
-          description.node_counts[simple_node_class] += 1
-
-          case node_class
-          when "org.graalvm.compiler.nodes.IfNode"
-            description.branches = true
-          when "org.graalvm.compiler.nodes.LoopBeginNode"
-            description.loops = true
-          when "org.graalvm.compiler.nodes.InvokeNode", "org.graalvm.compiler.nodes.InvokeWithExceptionNode"
-            description.calls = true
+            case node_class
+            when "org.graalvm.compiler.nodes.IfNode"
+              description.branches = true
+            when "org.graalvm.compiler.nodes.LoopBeginNode"
+              description.loops = true
+            when "org.graalvm.compiler.nodes.InvokeNode", "org.graalvm.compiler.nodes.InvokeWithExceptionNode"
+              description.calls = true
+            end
+          elsif node.props[:synthetic_class]
+            description.node_counts["*" + node.props[:synthetic_class]] += 1
           end
-        end
 
-        description.deopts = graph.nodes[0].outputs.map(&:to)
-          .all? { |t| t.node_class == "org.graalvm.compiler.nodes.DeoptimizeNode" }
+          description.deopts = graph.nodes[0].outputs.map(&:to)
+            .all? { |t| t.node_class == "org.graalvm.compiler.nodes.DeoptimizeNode" }
+        end
 
         formatter = formatter_module::DescribeFormatter.new(graph, description)
         @out.puts formatter.format
@@ -405,16 +422,7 @@ module Seafoam
       raise ArgumentError, "render needs at least a graph" unless graph_index
       raise ArgumentError, "render only works with a graph" unless rest == [nil, nil]
 
-      pass_options = {
-        simplify_truffle_args: true,
-        hide_frame_state: true,
-        hide_pi: true,
-        hide_begin_end: true,
-        hide_floating: false,
-        reduce_edges: true,
-        simplify_alloc: true,
-        hide_null_fields: true,
-      }
+      pass_options = DEFAULT_PASS_OPTIONS.dup
       spotlight_nodes = nil
       args = args.dup
       out_file = nil
@@ -471,12 +479,7 @@ module Seafoam
         when "--no-reduce-edges"
           pass_options[:reduce_edges] = false
         when "--no-simplify"
-          pass_options[:simplify_truffle_args] = false
-          pass_options[:simplify_alloc] = false
-          pass_options[:hide_null_fields] = false
-          pass_options[:hide_pi] = false
-          pass_options[:hide_begin_end] = false
-          pass_options[:reduce_edges] = false
+          pass_options.merge!(NO_SIMPLIFY_PASS_OPTIONS)
         when "--draw-blocks"
           draw_blocks = true
         when "--option"
@@ -701,5 +704,25 @@ module Seafoam
       end
       # Don't worry if it fails.
     end
+
+    DEFAULT_PASS_OPTIONS = {
+      simplify_truffle_args: true,
+      hide_frame_state: true,
+      hide_pi: true,
+      hide_begin_end: true,
+      hide_floating: false,
+      reduce_edges: true,
+      simplify_alloc: true,
+      hide_null_fields: true,
+    }
+
+    NO_SIMPLIFY_PASS_OPTIONS = {
+      simplify_truffle_args: false,
+      simplify_alloc: false,
+      hide_null_fields: false,
+      hide_pi: false,
+      hide_begin_end: false,
+      reduce_edges: false,
+    }
   end
 end

--- a/lib/seafoam/commands.rb
+++ b/lib/seafoam/commands.rb
@@ -470,6 +470,13 @@ module Seafoam
           pass_options[:hide_floating] = true
         when "--no-reduce-edges"
           pass_options[:reduce_edges] = false
+        when "--no-simplify"
+          pass_options[:simplify_truffle_args] = false
+          pass_options[:simplify_alloc] = false
+          pass_options[:hide_null_fields] = false
+          pass_options[:hide_pi] = false
+          pass_options[:hide_begin_end] = false
+          pass_options[:reduce_edges] = false
         when "--draw-blocks"
           draw_blocks = true
         when "--option"
@@ -644,6 +651,7 @@ module Seafoam
       @out.puts "               --show-begin-end"
       @out.puts "               --hide-floating"
       @out.puts "               --no-reduce-edges"
+      @out.puts "               --no-simplify"
       @out.puts "               --draw-blocks"
       @out.puts "               --option key value"
       @out.puts "        --help"

--- a/lib/seafoam/formatters/json.rb
+++ b/lib/seafoam/formatters/json.rb
@@ -9,7 +9,7 @@ module Seafoam
       class DescribeFormatter < Seafoam::Formatters::Base::DescribeFormatter
         def format
           ret = Seafoam::Graal::GraphDescription::ATTRIBUTES.map { |attr| [attr, description.send(attr)] }.to_h
-          ret[:node_count] = graph.nodes.size
+          ret[:node_count] = graph.nodes.values.count { |n| !n.props[:hidden] }
           ret[:node_counts] = description.sorted_node_counts
 
           ret.to_json

--- a/lib/seafoam/formatters/text.rb
+++ b/lib/seafoam/formatters/text.rb
@@ -7,9 +7,10 @@ module Seafoam
       class DescribeFormatter < Seafoam::Formatters::Base::DescribeFormatter
         def format
           notes = Seafoam::Graal::GraphDescription::ATTRIBUTES.select { |attr| description.send(attr) }
+          unhidden_count = graph.nodes.values.count { |n| !n.props[:hidden] }
           node_counts = description.sorted_node_counts.map { |node_class, count| "#{node_class}: #{count}" }.join("\n")
 
-          ["#{graph.nodes.size} nodes", *notes].join(", ") + "\n#{node_counts}"
+          ["#{unhidden_count} nodes", *notes].join(", ") + "\n#{node_counts}"
         end
       end
 

--- a/lib/seafoam/passes/truffle.rb
+++ b/lib/seafoam/passes/truffle.rb
@@ -38,7 +38,7 @@ module Seafoam
           index = index_node.props["rawvalue"]
 
           arg_node = graph.create_node(graph.new_id,
-            { synthetic: true, inlined: true, label: "T(#{index})", kind: "input" })
+            { synthetic: true, synthetic_class: "TruffleArgument", inlined: true, label: "T(#{index})", kind: "input" })
 
           node.outputs.each do |output|
             next if output.props[:name] == "next"
@@ -91,7 +91,8 @@ module Seafoam
             end
             raise unless fields.size == values.size
 
-            new_node = graph.create_node(graph.new_id, { synthetic: true, label: label, kind: "alloc" })
+            new_node = graph.create_node(graph.new_id,
+              { synthetic: true, synthetic_class: "TruffleNew", label: label, kind: "alloc" })
 
             object = [new_node, virtual_node, fields, values]
             objects << object

--- a/seafoam.gemspec
+++ b/seafoam.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency("rake", "~> 13.0.6")
   spec.add_development_dependency("rspec", "~> 3.8")
-  spec.add_development_dependency("rubocop-shopify", "~> 2.9.0")
+  spec.add_development_dependency("rubocop-shopify", ">= 2.9.0")
 end

--- a/spec/seafoam/command_spec.rb
+++ b/spec/seafoam/command_spec.rb
@@ -394,8 +394,6 @@ describe Seafoam::Commands do
           20 nodes, branches, calls
           AddNode: 3
           ConstantNode: 3
-          BeginNode: 2
-          FrameState: 2
           HotSpotDirectCallTargetNode: 2
           InvokeNode: 2
           ReturnNode: 2
@@ -425,8 +423,6 @@ describe Seafoam::Commands do
           "node_counts" => {
             "AddNode" => 3,
             "ConstantNode" => 3,
-            "BeginNode" => 2,
-            "FrameState" => 2,
             "HotSpotDirectCallTargetNode" => 2,
             "InvokeNode" => 2,
             "ReturnNode" => 2,

--- a/spec/seafoam/command_spec.rb
+++ b/spec/seafoam/command_spec.rb
@@ -391,7 +391,7 @@ describe Seafoam::Commands do
       it "prints a description of a particular graph index" do
         @commands.send(:describe, "#{@fib_java}:4", Seafoam::Formatters::Text)
         expect(@out.string).to(eq(<<~EXPECTED))
-          20 nodes, branches, calls
+          16 nodes, branches, calls
           AddNode: 3
           ConstantNode: 3
           HotSpotDirectCallTargetNode: 2
@@ -419,7 +419,7 @@ describe Seafoam::Commands do
           "loops" => false,
           "deopts" => false,
           "linear" => false,
-          "node_count" => 20,
+          "node_count" => 16,
           "node_counts" => {
             "AddNode" => 3,
             "ConstantNode" => 3,

--- a/spec/seafoam/command_spec.rb
+++ b/spec/seafoam/command_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "stringio"
-require "tempfile"
+require "tmpdir"
 
 require "seafoam"
 
@@ -302,23 +302,31 @@ describe Seafoam::Commands do
 
     it "can render all BGV files to dot" do
       Seafoam::SpecHelpers::SAMPLE_BGV.each do |file|
-        @commands.send(:render, "#{file}:2", "--out", "out.dot")
+        Dir.mktmpdir do |dir|
+          @commands.send(:render, "#{file}:2", "--out", "#{dir}/out.dot")
+        end
       end
     end
 
     it "supports --out out.dot" do
-      @commands.send(:render, "#{@fib_java}:0", "--out", "out.dot")
-      expect(%x(file out.dot)).to(start_with("out.dot: ASCII text"))
+      Dir.mktmpdir do |dir|
+        @commands.send(:render, "#{@fib_java}:0", "--out", "#{dir}/out.dot")
+        expect(%x(file #{dir}/out.dot)).to(start_with("#{dir}/out.dot: ASCII text"))
+      end
     end
 
     it "supports --out out.mmd" do
-      @commands.send(:render, "#{@fib_java}:0", "--out", "out.mmd")
-      expect(File.read("out.mmd")).to(start_with("flowchart TD"))
+      Dir.mktmpdir do |dir|
+        @commands.send(:render, "#{@fib_java}:0", "--out", "#{dir}/out.mmd")
+        expect(File.read("#{dir}/out.mmd")).to(start_with("flowchart TD"))
+      end
     end
 
     it "supports --out out.md" do
-      @commands.send(:render, "#{@fib_java}:0", "--out", "out.md")
-      expect(File.read("out.md")).to(start_with("```mermaid"))
+      Dir.mktmpdir do |dir|
+        @commands.send(:render, "#{@fib_java}:0", "--out", "#{dir}/out.md")
+        expect(File.read("#{dir}/out.md")).to(start_with("```mermaid"))
+      end
     end
 
     it "supports --md" do
@@ -327,28 +335,38 @@ describe Seafoam::Commands do
     end
 
     it "supports spotlighting nodes" do
-      @commands.send(:render, "#{@fib_java}:0", "--spotlight", "13", "--out", "out.dot")
+      Dir.mktmpdir do |dir|
+        @commands.send(:render, "#{@fib_java}:0", "--spotlight", "13", "--out", "#{dir}/out.dot")
+      end
     end
 
     if Seafoam::SpecHelpers.dependencies_installed?
       it "supports --out out.pdf" do
-        @commands.send(:render, "#{@fib_java}:0", "--out", "out.pdf")
-        expect(%x(file out.pdf)).to(start_with("out.pdf: PDF document"))
+        Dir.mktmpdir do |dir|
+          @commands.send(:render, "#{@fib_java}:0", "--out", "#{dir}/out.pdf")
+          expect(%x(file #{dir}/out.pdf)).to(start_with("#{dir}/out.pdf: PDF document"))
+        end
       end
 
       it "supports --out out.svg" do
-        @commands.send(:render, "#{@fib_java}:0", "--out", "out.svg")
-        expect(%x(file out.svg)).to(start_with("out.svg: SVG Scalable Vector Graphics image"))
+        Dir.mktmpdir do |dir|
+          @commands.send(:render, "#{@fib_java}:0", "--out", "#{dir}/out.svg")
+          expect(%x(file #{dir}/out.svg)).to(start_with("#{dir}/out.svg: SVG Scalable Vector Graphics image"))
+        end
       end
 
       it "supports --out out.png" do
-        @commands.send(:render, "#{@fib_java}:0", "--out", "out.png")
-        expect(%x(file out.png)).to(start_with("out.png: PNG image data"))
+        Dir.mktmpdir do |dir|
+          @commands.send(:render, "#{@fib_java}:0", "--out", "#{dir}/out.png")
+          expect(%x(file #{dir}/out.png)).to(start_with("#{dir}/out.png: PNG image data"))
+        end
       end
     else
       it "raises an exception if Graphviz is not installed" do
         expect do
-          @commands.send(:render, "#{@fib_java}:0", "--out", "out.pdf")
+          Dir.mktmpdir do |dir|
+            @commands.send(:render, "#{@fib_java}:0", "--out", "#{dir}/out.pdf")
+          end
         end.to(raise_error(RuntimeError, /Could not run Graphviz - is it installed?/))
       end
     end


### PR DESCRIPTION
Fixes #65

Before:

```
% bundle exec bin/seafoam examples/fib-ruby.bgv.gz:2 describe --no-simplify
138 nodes, branches, calls
ConstantNode: 15
LoadIndexedNode: 8
PiNode: 5
FixedGuardNode: 4
BoxNode$AllocatingBoxNode: 3
BoxNode$TrustedBoxedValue: 3
UnboxNode: 3
AllocatedObjectNode: 2
BeginNode: 2
CommitAllocationNode: 2
DeoptimizeNode: 2
EndNode: 2
ExceptionObjectNode: 2
IntegerSubExactNode: 2
IntegerSubExactOverflowNode: 2
InvokeWithExceptionNode: 2
KillingBeginNode: 2
MethodCallTargetNode: 2
VirtualArrayNode: 2
IfNode: 1
IntegerAddExactNode: 1
IntegerAddExactOverflowNode: 1
IntegerLessThanNode: 1
MergeNode: 1
ObjectEqualsNode: 1
ParameterNode: 1
PiArrayNode: 1
ReturnNode: 1
StartNode: 1
ValuePhiNode: 1
```

After:

```
% bundle exec bin/seafoam examples/fib-ruby.bgv.gz:2 describe
148 nodes, branches, calls
ConstantNode: 7
FixedGuardNode: 4
BoxNode$AllocatingBoxNode: 3
BoxNode$TrustedBoxedValue: 3
UnboxNode: 3
*TruffleArgument: 2
*TruffleNew: 2
DeoptimizeNode: 2
ExceptionObjectNode: 2
IntegerSubExactNode: 2
IntegerSubExactOverflowNode: 2
InvokeWithExceptionNode: 2
KillingBeginNode: 2
MethodCallTargetNode: 2
IfNode: 1
IntegerAddExactNode: 1
IntegerAddExactOverflowNode: 1
IntegerLessThanNode: 1
MergeNode: 1
ObjectEqualsNode: 1
ReturnNode: 1
StartNode: 1
ValuePhiNode: 1
```

Note that synthetic nodes have a `*` in front of their name.

CC @eregon 