### PR TITLE
Update class name matching rule for allocation simplification to match more valid class names.

### DIFF
--- a/lib/seafoam/passes/truffle.rb
+++ b/lib/seafoam/passes/truffle.rb
@@ -83,7 +83,12 @@ module Seafoam
 
             virtual_id = m[1].to_i
 
-            (m = /^(\w+(?:\[\])?)\[([0-9,]+)\]$/.match(value)) || raise(value)
+            m = /^([[:alnum:]$]+(?:\[\])?)\[([0-9,]+)\]$/.match(value)
+
+            unless m
+              raise "Unexpected value in allocation node: '#{value}'"
+            end
+
             class_name, values = m.captures
             values = values.split(",").map(&:to_i)
             virtual_node = graph.nodes[virtual_id]


### PR DESCRIPTION
The existing rule for matching class names in the allocation simplification pass didn't handle "$" inside names. I also updated the rule to match against non-ASCII Unicode characters, although I didn't need that for graphs I was looking at. Finally, I added more context to the error message because the message that was printed looked like:

> seafoam: MarkingService$ExtensionCallStackEntry[5,5,3577,41,41,195,139,41,41,41,41]

and I couldn't immediately work out what that meant.

We may want to consider adding the ability to print debug data through an environment variable or a flag to Seafoam. Relying on `ruby -d` is a little awkward when the primary execution mechanism is the `seafoam` binary.