### PR TITLE
Fix issue with nil `node_class` value on Truffle synthentic nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ New Features:
 
 Bug Fixes:
 
+* Fixed an error calling `describe` on graphs with Truffle arg simplification (#90, @nirvdrum).
+
 Changes:
 
 

--- a/lib/seafoam/graph.rb
+++ b/lib/seafoam/graph.rb
@@ -63,7 +63,11 @@ module Seafoam
     end
 
     def node_class
-      @props.dig(:node_class, :node_class) || ""
+      if @props[:synthetic] == true
+        @props[:synthetic_class]
+      else
+        @props.dig(:node_class, :node_class)
+      end
     end
 
     # All edges - input and output.

--- a/spec/seafoam/passes/truffle_spec.rb
+++ b/spec/seafoam/passes/truffle_spec.rb
@@ -90,6 +90,9 @@ describe Seafoam::Passes::TrufflePass do
           expect(after_truffle_argument_nodes).not_to(be_empty)
 
           after_truffle_argument_nodes.each_with_index do |arg_node, index|
+            # The node_class should be the synthetic class value.
+            expect(arg_node.node_class).to(eq("TruffleArgument"))
+
             # The "next" edges are never connected to the TruffleArgument node.
             rewritten_edges = before_load_indexed_nodes[index].outputs.select { |edge| edge.props[:name] != "next" }
 


### PR DESCRIPTION
Notably, this eliminates an exception being raised when using the `describe` command on a graph with such nodes.