### PR TITLE
Centralize Ruby Version to `.ruby-version`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
         bundler-cache: true
     - name: Install dependencies
       run: if [[ $(uname) == "Darwin" ]]; then brew install graphviz; else sudo apt-get install graphviz; fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
         bundler-cache: true
     - env:
         NO_DEPENDENCIES_INSTALLED: true


### PR DESCRIPTION
## What are you trying to accomplish?
The `.ruby-version` file is the ecosystem standard for defining a Ruby version.  This PR removes all other references to Ruby in this repository.

## What should reviewers focus on?
> [!IMPORTANT] 
> Please verify the following before merging:

Verify that the changes in the PR meets the following requirements or adjust manually to make it compliant:
  - [x] `.ruby-version` file is present with the correct Ruby version defined
  - [x] A `required_ruby_version` in your gemspec is set
  - [x] There is no Ruby version/requirement referenced in the `Gemfile` (no lines with `ruby  <some-version>`)
  - [x] There is no `TargetRubyVersion` defined  in `rubocop.yml` (reads from  `required_ruby_version` on Rubocop 1.61.0)
  - [x] There is no Ruby argument  present in  `ruby/setup-ruby` Github Actions that do **not**  run on a Ruby matrix (no lines with `ruby-version: “x.x”`)

Please merge this PR if it looks good, this PR will be addressed if there isn't any activity after 4 weeks.
